### PR TITLE
Composer package removal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,6 @@
         "source": "https://github.com/fusioncms/quotes-module",
         "chat": "https://beta.getfusioncms.com/discord"
     },
-    "require": {
-    	"firebase/php-jwt": "5.0.0"
-    },
     "autoload": {
         "classmap": [
             "database/"


### PR DESCRIPTION
This update removes the `firebase/php-jwt` composer package requirement as it isn't used.

- closes #10 